### PR TITLE
feat: add ws engine to auto init

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ function FuzzerPlugin (script, events) {
 
     scenario.beforeRequest.push('fuzzerPluginCreateVariable');
 
-    if (scenario.engine === 'socketio') {
+    if (['socketio', 'ws'].includes(scenario.engine)) {
       scenario.flow.unshift({function: 'fuzzerPluginCreateVariable'});
     }
   });

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Fuzz your HTTP APIs with Artillery",
   "main": "index.js",
   "scripts": {
-    "test": "node test/index.js",
+    "test": "tape test/*",
     "commitmsg": "conventional-changelog-lint -e",
     "precommit": "semistandard"
   },

--- a/test/ws_engine.js
+++ b/test/ws_engine.js
@@ -1,0 +1,19 @@
+'use strict';
+const test = require('tape');
+const { Plugin } = require('../index');
+
+test('should add a fuzzerPluginCreateVariable function with a ws scenario', function (t) {
+  t.plan(4);
+
+  let script = {
+    config: {},
+    scenarios: [{ engine: 'ws', flow: [] }]
+  };
+
+  t.doesNotThrow(() => {
+    t.ok(new Plugin(script));
+    let { flow } = script.scenarios[0];
+    t.equals(flow.length, 1, 'should add an init step');
+    t.equals(flow[0].function, 'fuzzerPluginCreateVariable', 'should add the create function');
+  });
+});


### PR DESCRIPTION
Simple change to add the `ws` engine to the auto detection.

The `test/index.js` was missing, so I just created a separate one for this scenario